### PR TITLE
refactor: add tailwind on login and sign up pages

### DIFF
--- a/client/src/components/Blog/PostCard.jsx
+++ b/client/src/components/Blog/PostCard.jsx
@@ -9,19 +9,17 @@ export default function PostCard({ post }) {
 
   return (
     <div className="max-w-sm rounded overflow-hidden shadow-lg bg-slate-200">
-    
-    <div className="px-6 py-4">
-      <div className="font-bold text-xl mb-2">{post.title}</div>
-      <p className="text-gray-700 text-base">
-        {post.body}
-      </p>
-    </div>
+      <div className="px-6 py-4">
+        <div className="font-bold text-xl mb-2">{post.title}</div>
+        <p className="text-gray-700 text-base">{post.body}</p>
+      </div>
 
-    <div className="flex items-center mt-4">
-      <img className="w-10 h-10 rounded-full mr-4" src="" alt="" />
-      <div className="text-sm">
-        <p className="text-gray-900 leading-none">Created by: {user.name} </p>
-        <p className="text-gray-600">{date}</p>
+      <div className="flex items-center mt-4">
+        <img className="w-10 h-10 rounded-full mr-4" src="" alt="" />
+        <div className="text-sm">
+          <p className="text-gray-900 leading-none">Created by: {user.name} </p>
+          <p className="text-gray-600">{date}</p>
+        </div>
       </div>
     </div>
   );

--- a/client/src/pages/LoginPage/LoginPage.jsx
+++ b/client/src/pages/LoginPage/LoginPage.jsx
@@ -50,59 +50,78 @@ function LoginPage() {
 
   return (
     <>
-    <div className="LoginPage">
-      <h1>Login</h1>
-
-      <form onSubmit={handleLoginSubmit}>
-  <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
-      <a href="#" class="flex items-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
-          <img class="w-8 h-8 mr-2" src="https://flowbite.s3.amazonaws.com/blocks/marketing-ui/logo.svg" alt="logo" />
-          Login   
-      </a>
-      <div class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
-          <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
-              <h1 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
-                  Sign in to your account
-              </h1>
-              <form class="space-y-4 md:space-y-6" action="#">
-                  <div>
-                      <label for="email" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Your email</label>
-                      <input type="email" name="email" id="email" value={email} onChange={handleEmail} class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="name@company.com" required=""/>
-                  </div>
-                  <div>
-                      <label for="password" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white" value={password}
-          onChange={handlePassword}>Password</label>
-                      <input type="password" name="password" id="password" placeholder="••••••••" class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" required=""/>
-                  </div>
-                  <div class="flex items-center justify-between">
-                      <div class="flex items-start">
-                          <div class="flex items-center h-5">
-                            <input id="remember" aria-describedby="remember" type="checkbox" class="w-4 h-4 border border-gray-300 rounded bg-gray-50 focus:ring-3 focus:ring-primary-300 dark:bg-gray-700 dark:border-gray-600 dark:focus:ring-primary-600 dark:ring-offset-gray-800" required="" />
-                          </div>
-                          <div class="ml-3 text-sm">
-                            <label for="remember" class="text-gray-500 dark:text-gray-300">Remember me</label>
-                          </div>
-                      </div>
-                      <a href="#" class="text-sm font-medium text-primary-600 hover:underline dark:text-primary-500">Forgot password?</a>
-                  </div>
-                  {errorMessage && <p className="error-message">{errorMessage}</p>}
-                  <button type="submit" class="w-full text-white bg-primary-600 hover:bg-primary-700 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800">Sign in</button>
-                  <p class="text-sm font-light text-gray-500 dark:text-gray-400">
-                      Don’t have an account yet? <Link to={"/signup"} class="font-medium text-primary-600 hover:underline dark:text-primary-500">Sign up</Link>
-                  </p>
-              </form>
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-md w-full space-y-8">
+          <div>
+            <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-700">
+              Sign in to your account
+            </h2>
           </div>
-      </div>
-  </div>
-      </form>
-      {errorMessage && <p className="error-message">{errorMessage}</p>}
+          <form onSubmit={handleLoginSubmit} className="mt-8 space-y-6">
+            <input type="hidden" name="remember" defaultValue="true" />
+            <div className="rounded-md shadow-sm -space-y-px">
+              <div>
+                <label htmlFor="email-address" className="sr-only">
+                  Email address
+                </label>
+                <input
+                  id="email-address"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                  placeholder="Email address"
+                  value={email}
+                  onChange={handleEmail}
+                />
+              </div>
+              <div>
+                <label htmlFor="password" className="sr-only">
+                  Password
+                </label>
+                <input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                  className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                  placeholder="Password"
+                  value={password}
+                  onChange={handlePassword}
+                />
+              </div>
+            </div>
 
-      <p>Don't have an account yet?</p>
-      <Link to={'/signup'}> Sign Up</Link>
-    </div>
+            {errorMessage && (
+              <p className="text-red-500 text-xs mt-2">{errorMessage}</p>
+            )}
+
+            <div className="flex items-center justify-between">
+              <div className="text-sm">
+                <Link
+                  to="/signup"
+                  className="font-medium text-gray-700 hover:text-gray-600"
+                >
+                  Don't have an account? Sign up
+                </Link>
+              </div>
+            </div>
+
+            <div>
+              <button
+                type="submit"
+                className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-gray-700 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              >
+                Sign in
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
     </>
   );
 }
-
 
 export default LoginPage;

--- a/client/src/pages/LoginPage/LoginPage.jsx
+++ b/client/src/pages/LoginPage/LoginPage.jsx
@@ -53,29 +53,60 @@ function LoginPage() {
   };
 
   return (
+    <>
     <div className="LoginPage">
       <h1>Login</h1>
 
       <form onSubmit={handleLoginSubmit}>
-        <label>Email:</label>
-        <input type="email" name="email" value={email} onChange={handleEmail} />
-
-        <label>Password:</label>
-        <input
-          type="password"
-          name="password"
-          value={password}
-          onChange={handlePassword}
-        />
-
-        <button type="submit">Login</button>
+  <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
+      <a href="#" class="flex items-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
+          <img class="w-8 h-8 mr-2" src="https://flowbite.s3.amazonaws.com/blocks/marketing-ui/logo.svg" alt="logo" />
+          Login   
+      </a>
+      <div class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
+          <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
+              <h1 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
+                  Sign in to your account
+              </h1>
+              <form class="space-y-4 md:space-y-6" action="#">
+                  <div>
+                      <label for="email" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Your email</label>
+                      <input type="email" name="email" id="email" value={email} onChange={handleEmail} class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="name@company.com" required=""/>
+                  </div>
+                  <div>
+                      <label for="password" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white" value={password}
+          onChange={handlePassword}>Password</label>
+                      <input type="password" name="password" id="password" placeholder="••••••••" class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" required=""/>
+                  </div>
+                  <div class="flex items-center justify-between">
+                      <div class="flex items-start">
+                          <div class="flex items-center h-5">
+                            <input id="remember" aria-describedby="remember" type="checkbox" class="w-4 h-4 border border-gray-300 rounded bg-gray-50 focus:ring-3 focus:ring-primary-300 dark:bg-gray-700 dark:border-gray-600 dark:focus:ring-primary-600 dark:ring-offset-gray-800" required="" />
+                          </div>
+                          <div class="ml-3 text-sm">
+                            <label for="remember" class="text-gray-500 dark:text-gray-300">Remember me</label>
+                          </div>
+                      </div>
+                      <a href="#" class="text-sm font-medium text-primary-600 hover:underline dark:text-primary-500">Forgot password?</a>
+                  </div>
+                  {errorMessage && <p className="error-message">{errorMessage}</p>}
+                  <button type="submit" class="w-full text-white bg-primary-600 hover:bg-primary-700 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800">Sign in</button>
+                  <p class="text-sm font-light text-gray-500 dark:text-gray-400">
+                      Don’t have an account yet? <Link to={"/signup"} class="font-medium text-primary-600 hover:underline dark:text-primary-500">Sign up</Link>
+                  </p>
+              </form>
+          </div>
+      </div>
+  </div>
       </form>
       {errorMessage && <p className="error-message">{errorMessage}</p>}
 
       <p>Don't have an account yet?</p>
       <Link to={"/signup"}> Sign Up</Link>
     </div>
+    </>
   );
 }
+
 
 export default LoginPage;

--- a/client/src/pages/SignupPage/SignupPage.jsx
+++ b/client/src/pages/SignupPage/SignupPage.jsx
@@ -46,32 +46,94 @@ function SignupPage() {
   };
 
   return (
-    <div className="SignupPage">
-      <h1>Sign Up</h1>
+    <>
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-md w-full space-y-8">
+          <div>
+            <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-700">
+              Sign in to your account
+            </h2>
+          </div>
+          <form onSubmit={handleSignupSubmit} className="mt-8 space-y-6">
+            <input type="hidden" name="remember" defaultValue="true" />
+            <div className="rounded-md shadow-sm -space-y-px">
+              <div>
+                <label htmlFor="email-address" className="sr-only">
+                  Email address
+                </label>
+                <input
+                  id="email-address"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                  placeholder="Email address"
+                  value={email}
+                  onChange={handleEmail}
+                />
+              </div>
+              <div>
+                <label htmlFor="password" className="sr-only">
+                  Password
+                </label>
+                <input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                  className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                  placeholder="Password"
+                  value={password}
+                  onChange={handlePassword}
+                />
+              </div>
+              <div>
+                <label htmlFor="name" className="sr-only">
+                  Name
+                </label>
+                <input
+                  id="name"
+                  name="name"
+                  type="text"
+                  autoComplete="current-password"
+                  required
+                  className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                  placeholder="Your name"
+                  value={name}
+                  onChange={handleName}
+                />
+              </div>
+            </div>
 
-      <form onSubmit={handleSignupSubmit}>
-        <label>Email:</label>
-        <input type="email" name="email" value={email} onChange={handleEmail} />
+            {errorMessage && (
+              <p className="text-red-500 text-xs mt-2">{errorMessage}</p>
+            )}
 
-        <label>Password:</label>
-        <input
-          type="password"
-          name="password"
-          value={password}
-          onChange={handlePassword}
-        />
+            <div className="flex items-center justify-between">
+              <div className="text-sm">
+                <Link
+                  to="/signup"
+                  className="font-medium text-gray-700 hover:text-gray-600"
+                >
+                  Don't have an account? Sign up
+                </Link>
+              </div>
+            </div>
 
-        <label>Name:</label>
-        <input type="text" name="name" value={name} onChange={handleName} />
-
-        <button type="submit">Sign Up</button>
-      </form>
-
-      {errorMessage && <p className="error-message">{errorMessage}</p>}
-
-      <p>Already have account?</p>
-      <Link to={'/login'}> Login</Link>
-    </div>
+            <div>
+              <button
+                type="submit"
+                className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-gray-700 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              >
+                Sign in
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/client/src/pages/SignupPage/SignupPage.jsx
+++ b/client/src/pages/SignupPage/SignupPage.jsx
@@ -117,7 +117,7 @@ function SignupPage() {
                   to="/login"
                   className="font-medium text-gray-700 hover:text-gray-600"
                 >
-                  Already have account?
+                  Already have account? Login
                 </Link>
               </div>
             </div>

--- a/client/src/pages/SignupPage/SignupPage.jsx
+++ b/client/src/pages/SignupPage/SignupPage.jsx
@@ -114,10 +114,10 @@ function SignupPage() {
             <div className="flex items-center justify-between">
               <div className="text-sm">
                 <Link
-                  to="/signup"
+                  to="/login"
                   className="font-medium text-gray-700 hover:text-gray-600"
                 >
-                  Don't have an account? Sign up
+                  Already have account?
                 </Link>
               </div>
             </div>


### PR DESCRIPTION
In this PR I'm adding temporary styling for the login and sign-up page.

## Type of Change


- [x] Refactoring (no new functionality, just code cleanup/refactoring)

## Testing Steps

<!-- Describe the steps to test this PR and verify the changes. -->

## Screenshots (if applicable)


<img width="553" alt="Screenshot 2023-03-31 at 23 47 07" src="https://user-images.githubusercontent.com/77642907/229238765-72432a93-7be6-42f0-aa9f-7f9648b3a1cf.png">



